### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ You can check that first link for the full details of how to get set up to use V
     - F1 and "Remote-Containers: Open Folder in Container..." the cloned repo.
 5. If no terminal appears in VS Code, open a New Terminal from the Terminal menu. 
 6. Inside that terminal, run `ucm --codebase-create ./devCodebase` to create a codebase.
-7. Run `ucm` to start developing!
+7. Run `ui` to start developing!
 
 
 Your codebase should be persisted even after rebuilding the container, but don't forget to also `push` it somewhere safe as a backup!
 
 Improvements, suggestions, and simplifications are welcome!
 
-Note: when running `ucm`, you'll get a message like: 
+Note: when running `ui`, you'll get a message like: 
 ```
   The Unison Codebase UI is running at
   http://127.0.0.1:39189/LMvqYeofPKwM7uOh5b7A%2FbtEM8tuN%2F%2Fu/ui


### PR DESCRIPTION
newbie here, so pardon me if I'm missing something obvious, but `ucm` does this:
```
.> ucm

  ⚠️
  I don't know how to ucm. Type `help` or `?` to get help.
```

Based on the interactive help it looks to me like this is talking about `ui` and not `ucm`.

---

Also, I get this error:
```
.> ui
http://127.0.0.1:44981/sTZtRYMIpcSuHxXa/ui: 1: xdg-open: not found
```

I'm on MacOS currently, I'll give it a whirl on Linux later and see how that goes.